### PR TITLE
ValidationQuery for Derby is fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
                 <jdbc.url><![CDATA[jdbc:derby://localhost/appfuse;create=true]]></jdbc.url>
                 <jdbc.username>any</jdbc.username>
                 <jdbc.password>value</jdbc.password>
-                <jdbc.validationQuery><![CDATA[SELECT 1 + 1]]></jdbc.validationQuery>
+                <jdbc.validationQuery><![CDATA[values 1]]></jdbc.validationQuery>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
ValidationQuery for Derby seems to be wrong. When we try to start
the app with Derby, it was giving SqlExceptions. After we changed
the ValidationQuery to correct version, it successfully passed.
Please check http://bit.ly/1d5rTxm as reference of the fix.
