### PR TITLE
Update LabelTag.java

### DIFF
--- a/web/spring/src/main/java/org/appfuse/webapp/taglib/LabelTag.java
+++ b/web/spring/src/main/java/org/appfuse/webapp/taglib/LabelTag.java
@@ -210,7 +210,24 @@ public class LabelTag extends TagSupport {
         colon = false;
         styleClass = null;
         errorClass = null;
+        requestContext = null;
     }
+
+/**
+ * Do End Tag to clear objects from memory
+ */
+public final int doEndTag()
+{
+     super.release();
+        key = null;
+        colon = false;
+        styleClass = null;
+        errorClass = null;
+        requestContext = null;
+        return 1;
+    
+}
+
 
     /**
      * Get the validator resources from a ValidatorFactory defined in the


### PR DESCRIPTION
Matt,

I noticed in our environment LabelTag was taking up a lot of memory, I added the doEndTag method to clear the requestContext which was what was taking up the memory in each user thread on the app server. For some reason just adding requestContext = null to the release method didn't work, I actually had to add the doEndTag method, after doing this the mem usaged dropped, I didn't notice any bugs as a result of this change.
