### PR TITLE
Update README.txt

### DIFF
--- a/archetypes/appfuse-modular-spring/src/README.txt
+++ b/archetypes/appfuse-modular-spring/src/README.txt
@@ -18,7 +18,7 @@ To get started, complete the following steps:
 1. Download and install a MySQL 5.x database from
    http://dev.mysql.com/downloads/mysql/5.0.html#downloads.
 
-2. From the command line, cd into the core directory and run "mvn install".
+2. From the command line, cd into the root directory and run "mvn install".
 
 3. From the command line, cd into the web directory and run "mvn jetty:run".
 


### PR DESCRIPTION
if run "mvn install" in the core directory,when run "mvn jetty:run" in the web directory will get "Could not find artifact com.mycompany:myproject-core:jar:1.0-SNAPSHOT in appfuse-snapshots " error.there is no myproject-1.0-SNAPSHOT.pom in the .m2\repository. when i run "mvn install" in the root directory. "mvn jetty:run" works.
